### PR TITLE
Fix: unpublishable config & demo-theme

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -48,12 +48,13 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             });
             $this->app->make('phpPageBuilder');
 
-            $this->publishes([
-                __DIR__ . '/../config/pagebuilder.php' => config_path('pagebuilder.php'),
-            ], 'config');
-            $this->publishes([
-                __DIR__ . '/../themes/demo' => base_path(config('pagebuilder.theme.folder_url') . '/demo'),
-            ], 'demo-theme');
         }
+
+        $this->publishes([
+            __DIR__ . '/../config/pagebuilder.php' => config_path('pagebuilder.php'),
+        ], 'config');
+        $this->publishes([
+            __DIR__ . '/../themes/demo' => base_path(config('pagebuilder.theme.folder_url') . '/demo'),
+        ], 'demo-theme');
     }
 }


### PR DESCRIPTION
Currently the config and demo theme are publishable only if schema has been already migrated. 
This PR aims to make the config publishable before the schema migration. 

Since the name of database depends on the config, publishing the config before schema migration give a more linear flow of installation.
https://github.com/HansSchouten/Laravel-Pagebuilder/blob/26898767ef6e441909fc8a4ce2de8581a78dc617/src/ServiceProvider.php#L34

Related issue:
#155 